### PR TITLE
Fix SSSE3 detection problem, probably due to cpuid v2.

### DIFF
--- a/gf2p16/slice_amd64.go
+++ b/gf2p16/slice_amd64.go
@@ -10,7 +10,7 @@ import (
 var hasSSSE3 bool
 
 func init() {
-	hasSSSE3 = cpuid.CPU.SSSE3()
+	hasSSSE3 = cpuid.CPU.Supports(cpuid.SSSE3)
 }
 
 // MulByteSliceLE treats in and out as arrays of Ts stored in


### PR DESCRIPTION
I had to make this modification to get `gopar` to build.