### PR TITLE
Fix up handling of subdirs for PAR1

### DIFF
--- a/cmd/par/main.go
+++ b/cmd/par/main.go
@@ -519,8 +519,8 @@ func main() {
 			panic(err)
 		}
 
-		repairedFiles, err := decoder.Repair(repairFlags.checkParity)
-		fmt.Printf("Repaired files: %v\n", repairedFiles)
+		repairedPaths, err := decoder.Repair(repairFlags.checkParity)
+		fmt.Printf("Repaired files: %v\n", repairedPaths)
 		needsRepair := false
 		exitCode := processVerifyOrRepairError(needsRepair, err)
 		os.Exit(exitCode)

--- a/cmd/par/main.go
+++ b/cmd/par/main.go
@@ -314,6 +314,19 @@ func newEncoder(parFile string, filePaths []string, sliceByteCount, numParitySha
 	if ext == ".par2" {
 		return par2.NewEncoder(par2LogEncoderDelegate{}, filePaths, sliceByteCount, numParityShards, numGoroutines)
 	}
+
+	parDir := filepath.Dir(parFile)
+	allFilesInSameDir := true
+	for _, p := range filePaths {
+		if filepath.Dir(p) != parDir {
+			allFilesInSameDir = false
+			break
+		}
+	}
+	if !allFilesInSameDir {
+		fmt.Printf("Warning: PAR and data files not all in the same directory, which a decoder will expect\n")
+	}
+
 	return par1.NewEncoder(par1LogEncoderDelegate{}, filePaths, numParityShards)
 }
 
@@ -418,10 +431,9 @@ func main() {
 			printUsageAndExit(name, createCommand, err)
 		}
 
-		parFile := createFlagSet.Arg(0)
-		files := createFlagSet.Args()[1:]
-
-		encoder, err := newEncoder(parFile, files, createFlags.sliceByteCount, createFlags.numParityShards, globalFlags.numGoroutines)
+		allFiles := createFlagSet.Args()
+		parFile, filePaths := allFiles[0], allFiles[1:]
+		encoder, err := newEncoder(parFile, filePaths, createFlags.sliceByteCount, createFlags.numParityShards, globalFlags.numGoroutines)
 		if err != nil {
 			panic(err)
 		}

--- a/par1/decoder.go
+++ b/par1/decoder.go
@@ -279,9 +279,9 @@ func (d *Decoder) Verify() (needsRepair bool, err error) {
 
 // Repair tries to repair any missing or corrupted data, using the
 // parity volumes. Returns a list of files that were successfully
-// repaired, which is present even if an error is returned. If
-// checkParity is true, extra checking is done of the reconstructed
-// parity data.
+// repaired in no particular order, which is present even if an error
+// is returned. If checkParity is true, extra checking is done of the
+// reconstructed parity data.
 func (d *Decoder) Repair(checkParity bool) ([]string, error) {
 	shards := d.buildShards()
 

--- a/par1/decoder.go
+++ b/par1/decoder.go
@@ -101,7 +101,12 @@ func (d *Decoder) LoadFileData() error {
 			continue
 		}
 
-		path := filepath.Join(dir, entry.filename)
+		filename := entry.filename
+		if filepath.Base(filename) != filename {
+			return errors.New("bad filename")
+		}
+
+		path := filepath.Join(dir, filename)
 		data, corrupt, err := func() ([]byte, bool, error) {
 			data, err := d.fileIO.ReadFile(path)
 			if os.IsNotExist(err) {

--- a/par1/decoder_test.go
+++ b/par1/decoder_test.go
@@ -237,12 +237,16 @@ func makeDecoderTestFileIO(t *testing.T, workingDir string) testFileIO {
 	})
 }
 
-func testVerify(t *testing.T, workingDir string) {
+func testVerify(t *testing.T, workingDir string, useAbsPath bool) {
 	io := makeDecoderTestFileIO(t, workingDir)
 
 	buildPARData(t, io, 3)
 
-	decoder, err := newDecoder(io, testDecoderDelegate{t}, "file.par")
+	parPath := "file.par"
+	if useAbsPath {
+		parPath = filepath.Join(workingDir, parPath)
+	}
+	decoder, err := newDecoder(io, testDecoderDelegate{t}, parPath)
 	require.NoError(t, err)
 	err = decoder.LoadFileData()
 	require.NoError(t, err)
@@ -292,9 +296,12 @@ func TestVerify(t *testing.T) {
 	}
 	for _, workingDir := range workingDirs {
 		workingDir := workingDir
-		t.Run(fmt.Sprintf("workingDir=%s", workingDir), func(t *testing.T) {
-			testVerify(t, workingDir)
-		})
+		for _, useAbsPath := range []bool{false, true} {
+			useAbsPath := useAbsPath
+			t.Run(fmt.Sprintf("workingDir=%s,useAbsPath=%t", workingDir, useAbsPath), func(t *testing.T) {
+				testVerify(t, workingDir, useAbsPath)
+			})
+		}
 	}
 }
 

--- a/par1/decoder_test.go
+++ b/par1/decoder_test.go
@@ -88,6 +88,10 @@ func (io testFileIO) removeData(path string) []byte {
 	return data
 }
 
+func (io testFileIO) moveData(oldPath, newPath string) {
+	io.setData(newPath, io.removeData(oldPath))
+}
+
 func (io testFileIO) ReadFile(path string) (data []byte, err error) {
 	io.t.Helper()
 	defer func() {

--- a/par1/decoder_test.go
+++ b/par1/decoder_test.go
@@ -380,14 +380,19 @@ func testRepair(t *testing.T, workingDir string, useAbsPath bool) {
 	err = decoder.LoadParityData()
 	require.NoError(t, err)
 
-	repaired, err := decoder.Repair(true)
+	repairedPaths, err := decoder.Repair(true)
 	require.NoError(t, err)
 
 	// removeData returns nil for "file.r03", but Repair writes a
 	// zero-length array instead.
 	expectedR03Data := []byte{}
-	// TODO: These should be absolute paths if useAbsPath is true.
-	require.Equal(t, []string{"file.r02", "file.r03", "file.r04"}, toSortedStrings(repaired))
+	expectedRepairedPaths := []string{"file.r02", "file.r03", "file.r04"}
+	if useAbsPath {
+		for i, path := range expectedRepairedPaths {
+			expectedRepairedPaths[i] = filepath.Join(workingDir, path)
+		}
+	}
+	require.Equal(t, toSortedStrings(expectedRepairedPaths), toSortedStrings(repairedPaths))
 	require.Equal(t, r02DataCopy, io.getData("file.r02"))
 	require.Equal(t, expectedR03Data, io.getData("file.r03"))
 	require.Equal(t, r04Data, io.getData("file.r04"))

--- a/par1/decoder_test.go
+++ b/par1/decoder_test.go
@@ -383,7 +383,7 @@ func testRepair(t *testing.T, workingDir string, useAbsPath bool) {
 	// zero-length array instead.
 	expectedR03Data := []byte{}
 	// TODO: These should be absolute paths if useAbsPath is true.
-	require.Equal(t, []string{"file.r02", "file.r03", "file.r04"}, repaired)
+	require.Equal(t, []string{"file.r02", "file.r03", "file.r04"}, toSortedStrings(repaired))
 	require.Equal(t, r02DataCopy, io.getData("file.r02"))
 	require.Equal(t, expectedR03Data, io.getData("file.r03"))
 	require.Equal(t, r04Data, io.getData("file.r04"))

--- a/par1/decoder_test.go
+++ b/par1/decoder_test.go
@@ -148,8 +148,8 @@ func buildPARData(t *testing.T, io testFileIO, parityShardCount int) {
 	}
 }
 
-func TestVerify(t *testing.T) {
-	io := testFileIO{
+func makeDecoderTestFileIO(t *testing.T) testFileIO {
+	return testFileIO{
 		t: t,
 		fileData: map[string][]byte{
 			"file.rar": {0x1, 0x2, 0x3, 0x4},
@@ -159,6 +159,10 @@ func TestVerify(t *testing.T) {
 			"file.r04": {0xd},
 		},
 	}
+}
+
+func TestVerify(t *testing.T) {
+	io := makeDecoderTestFileIO(t)
 
 	buildPARData(t, io, 3)
 
@@ -206,25 +210,8 @@ func TestVerify(t *testing.T) {
 }
 
 func TestSetHashMismatch(t *testing.T) {
-	io1 := testFileIO{
-		t: t,
-		fileData: map[string][]byte{
-			"file.rar": {0x1, 0x2, 0x3, 0x4},
-			"file.r01": {0x5, 0x6, 0x7},
-			"file.r02": {0x8, 0x9, 0xa, 0xb, 0xc},
-			"file.r03": nil,
-			"file.r04": {0xd},
-		},
-	}
-
-	io2 := testFileIO{
-		t:        t,
-		fileData: make(map[string][]byte),
-	}
-	for k, v := range io1.fileData {
-		io2.fileData[k] = make([]byte, len(v))
-		copy(io2.fileData[k], v)
-	}
+	io1 := makeDecoderTestFileIO(t)
+	io2 := makeDecoderTestFileIO(t)
 	io2.fileData["file.rar"][0]++
 
 	buildPARData(t, io1, 3)
@@ -241,16 +228,7 @@ func TestSetHashMismatch(t *testing.T) {
 }
 
 func TestRepair(t *testing.T) {
-	io := testFileIO{
-		t: t,
-		fileData: map[string][]byte{
-			"file.rar": {0x1, 0x2, 0x3, 0x4},
-			"file.r01": {0x5, 0x6, 0x7},
-			"file.r02": {0x8, 0x9, 0xa, 0xb, 0xc},
-			"file.r03": nil,
-			"file.r04": {0xd},
-		},
-	}
+	io := makeDecoderTestFileIO(t)
 
 	buildPARData(t, io, 3)
 

--- a/par1/encoder.go
+++ b/par1/encoder.go
@@ -2,6 +2,7 @@ package par1
 
 import (
 	"crypto/md5"
+	"errors"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -32,6 +33,14 @@ type EncoderDelegate interface {
 }
 
 func newEncoder(fileIO fileIO, delegate EncoderDelegate, filePaths []string, volumeCount int) (*Encoder, error) {
+	filenames := make(map[string]bool)
+	for _, p := range filePaths {
+		filename := filepath.Base(p)
+		if filenames[filename] {
+			return nil, errors.New("filename collision")
+		}
+		filenames[filename] = true
+	}
 	// TODO: Check len(filePaths) and volumeCount.
 	return &Encoder{fileIO, delegate, filePaths, volumeCount, 0, nil, nil}, nil
 }

--- a/par1/encoder_test.go
+++ b/par1/encoder_test.go
@@ -21,8 +21,8 @@ func (d testEncoderDelegate) OnVolumeFileWrite(i, n int, path string, dataByteCo
 	d.t.Logf("OnVolumeFileWrite(%d, %d, %s, dataByteCount=%d, byteCount=%d, %v)", i, n, path, dataByteCount, byteCount, err)
 }
 
-func TestEncodeParity(t *testing.T) {
-	io := testFileIO{
+func makeEncoderTestFileIO(t *testing.T) testFileIO {
+	return testFileIO{
 		t: t,
 		fileData: map[string][]byte{
 			"file.rar": {0x1, 0x2, 0x3},
@@ -32,6 +32,10 @@ func TestEncodeParity(t *testing.T) {
 			"file.r04": nil,
 		},
 	}
+}
+
+func TestEncodeParity(t *testing.T) {
+	io := makeEncoderTestFileIO(t)
 
 	paths := []string{"file.rar", "file.r01", "file.r02", "file.r03", "file.r04"}
 
@@ -60,16 +64,7 @@ func TestEncodeParity(t *testing.T) {
 }
 
 func TestWriteParity(t *testing.T) {
-	io := testFileIO{
-		t: t,
-		fileData: map[string][]byte{
-			"file.rar": {0x1, 0x2, 0x3},
-			"file.r01": {0x5, 0x6, 0x7, 0x8},
-			"file.r02": {0x9, 0xa, 0xb, 0xc},
-			"file.r03": {0xd, 0xe},
-			"file.r04": nil,
-		},
-	}
+	io := makeEncoderTestFileIO(t)
 
 	paths := []string{"file.rar", "file.r01", "file.r02", "file.r03", "file.r04"}
 

--- a/par1/encoder_test.go
+++ b/par1/encoder_test.go
@@ -1,6 +1,7 @@
 package par1
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/klauspost/reedsolomon"
@@ -23,11 +24,11 @@ func (d testEncoderDelegate) OnVolumeFileWrite(i, n int, path string, dataByteCo
 
 func makeEncoderTestFileIO(t *testing.T) testFileIO {
 	return makeTestFileIO(t, rootDir(), map[string][]byte{
-		"file.rar": {0x1, 0x2, 0x3},
-		"file.r01": {0x5, 0x6, 0x7, 0x8},
-		"file.r02": {0x9, 0xa, 0xb, 0xc},
-		"file.r03": {0xd, 0xe},
-		"file.r04": nil,
+		"file.rar":                                {0x1, 0x2, 0x3},
+		filepath.Join("dir1", "file.r01"):         {0x5, 0x6, 0x7, 0x8},
+		filepath.Join("dir2", "file.r02"):         {0x9, 0xa, 0xb, 0xc},
+		filepath.Join("dir2", "dir3", "file.r03"): {0xd, 0xe},
+		filepath.Join("dir4", "dir5", "file.r04"): nil,
 	})
 }
 
@@ -77,6 +78,10 @@ func TestWriteParity(t *testing.T) {
 
 	err = encoder.Write("parity.par")
 	require.NoError(t, err)
+
+	for _, path := range paths {
+		io.moveData(path, filepath.Base(path))
+	}
 
 	decoder, err := newDecoder(io, testDecoderDelegate{t}, "parity.par")
 	require.NoError(t, err)

--- a/par1/encoder_test.go
+++ b/par1/encoder_test.go
@@ -37,7 +37,7 @@ func makeEncoderTestFileIO(t *testing.T) testFileIO {
 func TestEncodeParity(t *testing.T) {
 	io := makeEncoderTestFileIO(t)
 
-	paths := []string{"file.rar", "file.r01", "file.r02", "file.r03", "file.r04"}
+	paths := io.paths()
 
 	encoder, err := newEncoder(io, testEncoderDelegate{t}, paths, 3)
 	require.NoError(t, err)
@@ -53,7 +53,8 @@ func TestEncodeParity(t *testing.T) {
 
 	var shards [][]byte
 	for _, path := range paths {
-		shards = append(shards, append(io.fileData[path], make([]byte, 4-len(io.fileData[path]))...))
+		data := io.getData(path)
+		shards = append(shards, append(data, make([]byte, 4-len(data))...))
 	}
 
 	shards = append(shards, encoder.parityData...)
@@ -66,7 +67,7 @@ func TestEncodeParity(t *testing.T) {
 func TestWriteParity(t *testing.T) {
 	io := makeEncoderTestFileIO(t)
 
-	paths := []string{"file.rar", "file.r01", "file.r02", "file.r03", "file.r04"}
+	paths := io.paths()
 
 	encoder, err := newEncoder(io, testEncoderDelegate{t}, paths, 3)
 	require.NoError(t, err)

--- a/par1/encoder_test.go
+++ b/par1/encoder_test.go
@@ -22,16 +22,13 @@ func (d testEncoderDelegate) OnVolumeFileWrite(i, n int, path string, dataByteCo
 }
 
 func makeEncoderTestFileIO(t *testing.T) testFileIO {
-	return testFileIO{
-		t: t,
-		fileData: map[string][]byte{
-			"file.rar": {0x1, 0x2, 0x3},
-			"file.r01": {0x5, 0x6, 0x7, 0x8},
-			"file.r02": {0x9, 0xa, 0xb, 0xc},
-			"file.r03": {0xd, 0xe},
-			"file.r04": nil,
-		},
-	}
+	return makeTestFileIO(t, rootDir(), map[string][]byte{
+		"file.rar": {0x1, 0x2, 0x3},
+		"file.r01": {0x5, 0x6, 0x7, 0x8},
+		"file.r02": {0x9, 0xa, 0xb, 0xc},
+		"file.r03": {0xd, 0xe},
+		"file.r04": nil,
+	})
 }
 
 func TestEncodeParity(t *testing.T) {

--- a/par1/encoder_test.go
+++ b/par1/encoder_test.go
@@ -1,6 +1,7 @@
 package par1
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -60,6 +61,16 @@ func TestEncodeParity(t *testing.T) {
 	ok, err := rs.Verify(shards)
 	require.NoError(t, err)
 	require.True(t, ok)
+}
+
+func TestEncodeParityFilenameCollision(t *testing.T) {
+	io := makeEncoderTestFileIO(t, rootDir())
+	io.setData(filepath.Join("dir6", "file.rar"), []byte{0x5, 0x6})
+
+	paths := io.paths()
+
+	_, err := newEncoder(io, testEncoderDelegate{t}, paths, 3)
+	require.Equal(t, errors.New("filename collision"), err)
 }
 
 func testWriteParity(t *testing.T, workingDir string, useAbsPath bool) {

--- a/par2/decoder.go
+++ b/par2/decoder.go
@@ -556,6 +556,8 @@ func (d *Decoder) Verify() (needsRepair bool, err error) {
 // repaired, which is present even if an error is returned. If
 // checkParity is true, extra checking is done of the reconstructed
 // parity data.
+//
+// TODO: Return paths instead of filenames.
 func (d *Decoder) Repair(checkParity bool) ([]string, error) {
 	coder, dataShards, err := d.newCoderAndShards()
 	if err != nil {


### PR DESCRIPTION
- Detect filenames that aren't just filenames on decode.
- Detect filename collision on encode.
- Warn if PAR files and data files aren't all in the same directory.
- Add tests for decoder/encoder behavior.

This will implement #9 for PAR1.