### PR TITLE
Fix up handling of subdirs for PAR2

### DIFF
--- a/cmd/par/main.go
+++ b/cmd/par/main.go
@@ -154,16 +154,16 @@ func (par2LogDecoderDelegate) OnParityFileLoad(i int, path string, err error) {
 	}
 }
 
-func (par2LogDecoderDelegate) OnDetectCorruptDataChunk(fileID [16]byte, filename string, startByteOffset, endByteOffset int) {
-	fmt.Printf("Corrupt data chunk: %q (ID %x), bytes %d to %d\n", filename, fileID, startByteOffset, endByteOffset-1)
+func (par2LogDecoderDelegate) OnDetectCorruptDataChunk(fileID [16]byte, path string, startByteOffset, endByteOffset int) {
+	fmt.Printf("Corrupt data chunk: %q (ID %x), bytes %d to %d\n", path, fileID, startByteOffset, endByteOffset-1)
 }
 
-func (par2LogDecoderDelegate) OnDetectDataFileHashMismatch(fileID [16]byte, filename string) {
-	fmt.Printf("Hash mismatch for %q (ID %x)\n", filename, fileID)
+func (par2LogDecoderDelegate) OnDetectDataFileHashMismatch(fileID [16]byte, path string) {
+	fmt.Printf("Hash mismatch for %q (ID %x)\n", path, fileID)
 }
 
-func (par2LogDecoderDelegate) OnDetectDataFileWrongByteCount(fileID [16]byte, filename string) {
-	fmt.Printf("Wrong byte count for %q (ID %x)\n", filename, fileID)
+func (par2LogDecoderDelegate) OnDetectDataFileWrongByteCount(fileID [16]byte, path string) {
+	fmt.Printf("Wrong byte count for %q (ID %x)\n", path, fileID)
 }
 
 func (par2LogDecoderDelegate) OnDataFileWrite(i, n int, path string, byteCount int, err error) {

--- a/cmd/par/main.go
+++ b/cmd/par/main.go
@@ -317,7 +317,15 @@ func newEncoder(parFile string, filePaths []string, sliceByteCount, numParitySha
 			return nil, err
 		}
 		basePath := filepath.Dir(parPath)
-		return par2.NewEncoder(par2LogEncoderDelegate{}, basePath, filePaths, sliceByteCount, numParityShards, numGoroutines)
+		absFilePaths := make([]string, len(filePaths))
+		for i, path := range filePaths {
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				return nil, err
+			}
+			absFilePaths[i] = absPath
+		}
+		return par2.NewEncoder(par2LogEncoderDelegate{}, basePath, absFilePaths, sliceByteCount, numParityShards, numGoroutines)
 	}
 
 	parDir := filepath.Dir(parFile)

--- a/cmd/par/main.go
+++ b/cmd/par/main.go
@@ -312,7 +312,12 @@ func newEncoder(parFile string, filePaths []string, sliceByteCount, numParitySha
 	// TODO: Detect file type more robustly.
 	ext := path.Ext(parFile)
 	if ext == ".par2" {
-		return par2.NewEncoder(par2LogEncoderDelegate{}, filePaths, sliceByteCount, numParityShards, numGoroutines)
+		parPath, err := filepath.Abs(parFile)
+		if err != nil {
+			return nil, err
+		}
+		basePath := filepath.Dir(parPath)
+		return par2.NewEncoder(par2LogEncoderDelegate{}, basePath, filePaths, sliceByteCount, numParityShards, numGoroutines)
 	}
 
 	parDir := filepath.Dir(parFile)

--- a/par2/decoder.go
+++ b/par2/decoder.go
@@ -560,9 +560,10 @@ func (d *Decoder) Verify() (needsRepair bool, err error) {
 
 // Repair tries to repair any missing or corrupted data, using the
 // parity volumes. Returns a list of paths to files that were
-// successfully repaired, which is present even if an error is
-// returned. If checkParity is true, extra checking is done of the
-// reconstructed parity data.
+// successfully repaired (relative to the indexFile passed to
+// NewDecoder) in no particular order, which is present even if an
+// error is returned. If checkParity is true, extra checking is done
+// of the reconstructed parity data.
 func (d *Decoder) Repair(checkParity bool) ([]string, error) {
 	coder, dataShards, err := d.newCoderAndShards()
 	if err != nil {

--- a/par2/decoder_test.go
+++ b/par2/decoder_test.go
@@ -300,10 +300,10 @@ func TestRepair(t *testing.T) {
 	err = decoder.LoadParityData()
 	require.NoError(t, err)
 
-	repaired, err := decoder.Repair(true)
+	repairedPaths, err := decoder.Repair(true)
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"file.r02", "file.r03", "file.r04"}, repaired)
+	require.Equal(t, []string{"file.r02", "file.r03", "file.r04"}, repairedPaths)
 	repairedR02Data, err := fs.ReadFile("file.r02")
 	require.NoError(t, err)
 	require.Equal(t, r02DataCopy, repairedR02Data)
@@ -341,10 +341,10 @@ func TestRepairAddedBytes(t *testing.T) {
 	err = decoder.LoadParityData()
 	require.NoError(t, err)
 
-	repaired, err := decoder.Repair(true)
+	repairedPaths, err := decoder.Repair(true)
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"file.rar"}, repaired)
+	require.Equal(t, []string{"file.rar"}, repairedPaths)
 	repairedRarData, err := fs.ReadFile("file.rar")
 	require.NoError(t, err)
 	require.Equal(t, rarDataCopy, repairedRarData)
@@ -376,10 +376,10 @@ func TestRepairRemovedBytes(t *testing.T) {
 	err = decoder.LoadParityData()
 	require.NoError(t, err)
 
-	repaired, err := decoder.Repair(true)
+	repairedPaths, err := decoder.Repair(true)
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"file.rar"}, repaired)
+	require.Equal(t, []string{"file.rar"}, repairedPaths)
 	repairedRarData, err := fs.ReadFile("file.rar")
 	require.NoError(t, err)
 	require.Equal(t, rarDataCopy, repairedRarData)
@@ -417,10 +417,10 @@ func TestRepairSwappedFiles(t *testing.T) {
 	err = decoder.LoadParityData()
 	require.NoError(t, err)
 
-	repaired, err := decoder.Repair(true)
+	repairedPaths, err := decoder.Repair(true)
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"file.rar", "file.r01"}, repaired)
+	require.Equal(t, []string{"file.rar", "file.r01"}, repairedPaths)
 	repairedRarData, err := fs.ReadFile("file.rar")
 	require.NoError(t, err)
 	require.Equal(t, rarData, repairedRarData)

--- a/par2/decoder_test.go
+++ b/par2/decoder_test.go
@@ -292,6 +292,13 @@ func TestSetIDMismatch(t *testing.T) {
 	require.False(t, needsRepair)
 }
 
+func toSortedStrings(arr []string) []string {
+	arrCopy := make([]string, len(arr))
+	copy(arrCopy, arr)
+	sort.Strings(arrCopy)
+	return arrCopy
+}
+
 func testRepair(t *testing.T, workingDir string, useAbsPath bool) {
 	fs := makeDecoderMemFS(workingDir)
 	r02Path := filepath.Join("dir1", "file.r02")
@@ -331,7 +338,7 @@ func testRepair(t *testing.T, workingDir string, useAbsPath bool) {
 			expectedRepairedPaths[i] = filepath.Join(workingDir, path)
 		}
 	}
-	require.Equal(t, expectedRepairedPaths, repairedPaths)
+	require.Equal(t, toSortedStrings(expectedRepairedPaths), toSortedStrings(repairedPaths))
 	repairedR02Data, err := fs.ReadFile(r02Path)
 	require.NoError(t, err)
 	require.Equal(t, r02DataCopy, repairedR02Data)
@@ -455,7 +462,7 @@ func TestRepairSwappedFiles(t *testing.T) {
 	repairedPaths, err := decoder.Repair(true)
 	require.NoError(t, err)
 
-	require.Equal(t, []string{"file.rar", "file.r01"}, repairedPaths)
+	require.Equal(t, []string{"file.r01", "file.rar"}, toSortedStrings(repairedPaths))
 	repairedRarData, err := fs.ReadFile("file.rar")
 	require.NoError(t, err)
 	require.Equal(t, rarData, repairedRarData)

--- a/par2/encoder.go
+++ b/par2/encoder.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"path/filepath"
 	"sort"
 
 	"github.com/akalin/gopar/rsec16"
@@ -43,7 +44,10 @@ type EncoderDelegate interface {
 	OnRecoveryFileWrite(start, count, total int, path string, dataByteCount, byteCount int, err error)
 }
 
-func newEncoder(fileIO fileIO, delegate EncoderDelegate, filePaths []string, sliceByteCount, parityShardCount, numGoroutines int) (*Encoder, error) {
+func newEncoder(fileIO fileIO, delegate EncoderDelegate, basePath string, filePaths []string, sliceByteCount, parityShardCount, numGoroutines int) (*Encoder, error) {
+	if !filepath.IsAbs(basePath) {
+		return nil, errors.New("basePath must be absolute")
+	}
 	// TODO: Check filePaths and parityShardCount.
 	if sliceByteCount == 0 || sliceByteCount%4 != 0 {
 		return nil, errors.New("invalid slice byte count")
@@ -52,9 +56,12 @@ func newEncoder(fileIO fileIO, delegate EncoderDelegate, filePaths []string, sli
 }
 
 // NewEncoder creates an encoder with the given list of file paths,
-// and with the given number of intended parity volumes.
-func NewEncoder(delegate EncoderDelegate, filePaths []string, sliceByteCount, parityShardCount, numGoroutines int) (*Encoder, error) {
-	return newEncoder(defaultFileIO{}, delegate, filePaths, sliceByteCount, parityShardCount, numGoroutines)
+// and with the given number of intended parity volumes. basePath must
+// be absolute.
+//
+// TODO: Mandate that elements of filePaths must also be absolute.
+func NewEncoder(delegate EncoderDelegate, basePath string, filePaths []string, sliceByteCount, parityShardCount, numGoroutines int) (*Encoder, error) {
+	return newEncoder(defaultFileIO{}, delegate, basePath, filePaths, sliceByteCount, parityShardCount, numGoroutines)
 }
 
 // LoadFileData loads the file data into memory.

--- a/par2/encoder_test.go
+++ b/par2/encoder_test.go
@@ -1,6 +1,7 @@
 package par2
 
 import (
+	"path/filepath"
 	"sort"
 	"testing"
 
@@ -34,11 +35,11 @@ func newEncoderForTest(t *testing.T, fs memfs.MemFS, basePath string, paths []st
 
 func makeEncoderMemFS(workingDir string) memfs.MemFS {
 	return memfs.MakeMemFS(workingDir, map[string][]byte{
-		"file.rar": {0x1, 0x2, 0x3},
-		"file.r01": {0x5, 0x6, 0x7, 0x8},
-		"file.r02": {0x9, 0xa, 0xb, 0xc},
-		"file.r03": {0xd, 0xe},
-		"file.r04": {0xf},
+		"file.rar":                                {0x1, 0x2, 0x3},
+		filepath.Join("dir1", "file.r01"):         {0x5, 0x6, 0x7, 0x8},
+		filepath.Join("dir1", "file.r02"):         {0x9, 0xa, 0xb, 0xc},
+		filepath.Join("dir2", "dir3", "file.r03"): {0xd, 0xe},
+		filepath.Join("dir4", "dir5", "file.r04"): {0xf},
 	})
 }
 
@@ -97,7 +98,13 @@ func TestWriteParity(t *testing.T) {
 	// newEncoderForTest() yet.
 	//
 	// TODO: Fix this.
-	paths := []string{"file.rar", "file.r01", "file.r02", "file.r03", "file.r04"}
+	paths := []string{
+		"file.rar",
+		filepath.Join("dir1", "file.r01"),
+		filepath.Join("dir1", "file.r02"),
+		filepath.Join("dir2", "dir3", "file.r03"),
+		filepath.Join("dir4", "dir5", "file.r04"),
+	}
 
 	sliceByteCount := 4
 	parityShardCount := 100

--- a/par2/file_description_packet.go
+++ b/par2/file_description_packet.go
@@ -34,9 +34,14 @@ func computeFileID(sixteenKHash [md5.Size]byte, byteCount uint64, filenameBytes 
 	return md5.Sum(hashInput)
 }
 
+// TODO: It's theoretically possible for filename to contain
+// backslashes -- check to see what par2cmdline does on Windows. We'd
+// then have to handle par files where the filenames have backslashes
+// but the current OS uses only forward slashes.
 func checkFilename(filename string) error {
+	// Filenames shouldn't be absolute, to preclude the repair process overwriting arbitrary
+	// files.
 	if path.IsAbs(filename) {
-		// TODO: Allow this via an option.
 		return errors.New("absolute paths not allowed")
 	}
 	filename = path.Clean(filename)

--- a/par2/file_test.go
+++ b/par2/file_test.go
@@ -56,19 +56,19 @@ func (d testDecoderDelegate) OnParityFileLoad(i int, path string, err error) {
 	d.t.Logf("OnParityFileLoad(%d, %s, %v)", i, path, err)
 }
 
-func (d testDecoderDelegate) OnDetectCorruptDataChunk(fileID [16]byte, filename string, startOffset, endOffset int) {
+func (d testDecoderDelegate) OnDetectCorruptDataChunk(fileID [16]byte, path string, startOffset, endOffset int) {
 	d.t.Helper()
-	d.t.Logf("OnDetectCorruptDataChunk(%x, %s, startOffset=%d, endOffset=%d)", fileID, filename, startOffset, endOffset)
+	d.t.Logf("OnDetectCorruptDataChunk(%x, %s, startOffset=%d, endOffset=%d)", fileID, path, startOffset, endOffset)
 }
 
-func (d testDecoderDelegate) OnDetectDataFileHashMismatch(fileID [16]byte, filename string) {
+func (d testDecoderDelegate) OnDetectDataFileHashMismatch(fileID [16]byte, path string) {
 	d.t.Helper()
-	d.t.Logf("OnDetectDataFileHashMismatch(%x, %s)", fileID, filename)
+	d.t.Logf("OnDetectDataFileHashMismatch(%x, %s)", fileID, path)
 }
 
-func (d testDecoderDelegate) OnDetectDataFileWrongByteCount(fileID [16]byte, filename string) {
+func (d testDecoderDelegate) OnDetectDataFileWrongByteCount(fileID [16]byte, path string) {
 	d.t.Helper()
-	d.t.Logf("OnDetectDataFileWrongByteCount(%x, %s)", fileID, filename)
+	d.t.Logf("OnDetectDataFileWrongByteCount(%x, %s)", fileID, path)
 }
 
 func (d testDecoderDelegate) OnDataFileWrite(i, n int, path string, byteCount int, err error) {


### PR DESCRIPTION
- On PAR2 creation, write data paths relative to the par2 file.
- Return an error sooner when data paths aren't in the base path.
- Convert some delegate functions to take paths.
- Add tests for decoder/encoder behavior.

This will implement #9 for PAR2.